### PR TITLE
Allow benchmark to be splitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The script has a limit of 1 day to run.
 This will run the queries against the triplestore and check if they are able to return a result.
 The results are stored in a file `./results/summary-conformity.json`.
 
-And inspect results in a human-readable format, run the following command:
+And inspect results in a human-readable format, run the following command (`jq` is required):
 
 ```sh
 ./scripts/summary-conformity-simple.sh
@@ -58,13 +58,20 @@ k6 run \
   lindas-benchmark.js
 ```
 
+In case you want to run the benchmark on some specific queries (it can be useful in order to check that it can hit your endpoint as expected), you can add those parameters:
+
+- `-e START=0`: The index of the first query to run (default: `0`)
+- `-e END=1125`: The index of the last query to run (default: `1125`)
+
 The query timeout is set to 2min30s.
 It will run 10 virtual users, that will run the maximum number of queries they can against the triplestore during 120s, and this for each query.
 
-The results are stored in a file `./results/summary-benchmark.json`.
+The results are stored in a file `./results/summary-benchmark-YYYY-MM-DDTHH-MM-SS.json`.
 
-To inspect the results in a human-readable format, run the following command:
+To inspect the results in a human-readable format, run the following command (`jq` is required):
 
 ```sh
-./scripts/summary-benchmark.sh
+./scripts/summary-benchmark.sh ./results/summary-benchmark-YYYY-MM-DDTHH-MM-SS.json
 ```
+
+by updating the path to the JSON file you want to inspect.

--- a/lindas-benchmark.js
+++ b/lindas-benchmark.js
@@ -8,7 +8,7 @@ const stepDuration = 120; // seconds
 
 const endpoint = __ENV.SPARQL_ENDPOINT;
 const startStr = __ENV.START || "0";
-const endStr = __ENV.END || "10";
+const endStr = __ENV.END || "1125";
 const start = parseInt(startStr);
 const end = parseInt(endStr);
 
@@ -39,7 +39,7 @@ const queries = new SharedArray('queries', function () {
 
 const trends = []
 const scenarios = {}
-for (let i = start; i < end; i++) {
+for (let i = start; i <= end; i++) {
   scenarios[`query_${i}`] = {
     executor: 'constant-vus',
     vus: 10,

--- a/scripts/summary-benchmark.sh
+++ b/scripts/summary-benchmark.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-# JSON input file
-input_json="./results/summary-benchmark.json"
+# JSON results file
+input_json="$1"
+if [ -z "${input_json}" ]; then
+  echo "Usage: $0 <results-json-file-path>"
+  exit 1
+fi
 
 # Extract and print query information
 jq -r '


### PR DESCRIPTION
This allows people to execute only a specific part of the benchmark.

This can be useful to make sure the benchmark is able to perform requests against the endpoint or not, and to identify the issues and fix them instead of waiting hours.

Closes #7.